### PR TITLE
Link T-4816 mounting new state-dump file location

### DIFF
--- a/boba_community/boba-node/docker-compose.yml
+++ b/boba_community/boba-node/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       DATA_TRANSPORT_LAYER__TURING_V0_HEIGHT: 381145
       DATA_TRANSPORT_LAYER__TURING_V1_HEIGHT: 381145
     volumes:
-      - ./:/opt/optimism/packages/data-transport-layer/state-dumps/
+      - ./state-dumps/state-dump-mainnet.latest.json:/opt/optimism/packages/data-transport-layer/state-dumps/state-dump.latest.json
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Updating volume mount to point to new location of state-dumps mainnet file.